### PR TITLE
make storage handle write safety

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 attrs
 django
+tenacity

--- a/toy_settings/services.py
+++ b/toy_settings/services.py
@@ -6,7 +6,6 @@ import uuid
 import attrs
 
 from . import events
-from . import projections
 from . import storage
 
 
@@ -47,8 +46,7 @@ class ToySettings:
         Raises:
             AlreadySet: The setting already exists.
         """
-        history = self.repo.events_for_key(key)
-        current_value = projections.current_value(key, history)
+        current_value = self.repo.current_value(key)
         if current_value is not None:
             raise AlreadySet(key)
 
@@ -76,8 +74,7 @@ class ToySettings:
         Raises:
             NotSet: There is no setting for this key.
         """
-        history = self.repo.events_for_key(key)
-        current_value = projections.current_value(key, history)
+        current_value = self.repo.current_value(key)
         if current_value is None:
             raise NotSet(key)
 
@@ -104,8 +101,7 @@ class ToySettings:
         Raises:
             NotSet: There is no setting for this key.
         """
-        history = self.repo.events_for_key(key)
-        current_value = projections.current_value(key, history)
+        current_value = self.repo.current_value(key)
         if current_value is None:
             raise NotSet(key)
 

--- a/toy_settings/storage.py
+++ b/toy_settings/storage.py
@@ -11,6 +11,12 @@ DEFAULT_TOY_SETTINGS_REPOSITORY_PATH = (
 )
 
 
+class StaleState(Exception):
+    """
+    An event could not be recorded because the state has changed.
+    """
+
+
 def get_repository() -> Repository:
     return import_string(DEFAULT_TOY_SETTINGS_REPOSITORY_PATH)()
 
@@ -18,15 +24,19 @@ def get_repository() -> Repository:
 class Repository(abc.ABC):
     @abc.abstractmethod
     def record(self, event: events.Event) -> None:
-        """Record a new event."""
+        """Record a new event.
+
+        Raises:
+            StaleState: The state has changed and recording is no longer safe.
+        """
         ...
+
+    # projections
 
     @abc.abstractmethod
     def events_for_key(self, key: str) -> list[events.Event]:
         """Retrieve the events for this key in chronological order."""
         ...
-
-    # projections
 
     @abc.abstractmethod
     def current_value(self, key: str) -> str | None:


### PR DESCRIPTION
- Add to repository interface to allow repos to handle write safety
- Use projections from repo directly in operations
- Retry operations if there are concurrency problems
