### PR TITLE
Use singledispatch for projections

### DIFF
--- a/toy_settings/projections.py
+++ b/toy_settings/projections.py
@@ -1,23 +1,37 @@
 from __future__ import annotations
 
+from functools import singledispatch
 from typing import Iterable
 
 from . import events
 
 
 def current_settings(history: Iterable[events.Event]) -> dict[str, str]:
-    settings = {}
+    settings: dict[str, str] = {}
     for event in sorted(history, key=lambda e: e.timestamp):
-        if isinstance(event, events.Set):
-            settings[event.key] = event.value
-        elif isinstance(event, events.Changed):
-            settings[event.key] = event.new_value
-        elif isinstance(event, events.Unset):
-            try:
-                del settings[event.key]
-            except KeyError:
-                pass
-        else:  # pragma: no cover
-            raise TypeError(f"unrecognised event type: {type(event)!r}")
+        _handle_event(event, settings)
 
     return settings
+
+
+@singledispatch
+def _handle_event(event: events.Event, settings: dict[str, str]) -> None:
+    raise TypeError(f"unrecognised event type: {type(event)!r}")  # pragma: no cover
+
+
+@_handle_event.register
+def _(event: events.Set, settings: dict[str, str]) -> None:
+    settings[event.key] = event.value
+
+
+@_handle_event.register
+def _(event: events.Changed, settings: dict[str, str]) -> None:
+    settings[event.key] = event.new_value
+
+
+@_handle_event.register
+def _(event: events.Unset, settings: dict[str, str]) -> None:
+    try:
+        del settings[event.key]
+    except KeyError:
+        pass


### PR DESCRIPTION
This also demonstrates that we can easily change our implementation
details without needing to change other things.

We maintain 100% test coverage and have reassurance all of our other tests work, but we don't need to modify any of them.
