### PR TITLE
Make domain services do something rather than return something

### DIFF
--- a/tests/domain/operations_test.py
+++ b/tests/domain/operations_test.py
@@ -6,23 +6,27 @@ import pytest
 
 from testing.domain import factories
 from testing.domain.queries import MemoryRepo
+from toy_settings.domain import events
 from toy_settings.domain import operations
 
 
 def test_set():
     repo = MemoryRepo()
-    toy_settings = operations.ToySettings(state=repo)
+    new_events: list[events.Event] = []
+    toy_settings = operations.ToySettings(state=repo, new_events=new_events)
 
     set_at = datetime.datetime.now()
-    new_events = toy_settings.set("FOO", "42", timestamp=set_at, by="me")
+    toy_settings.set("FOO", "42", timestamp=set_at, by="me")
 
-    assert new_events == factories.Set(
-        key="FOO",
-        value="42",
-        timestamp=set_at,
-        by="me",
-        index=0,
-    )
+    assert new_events == [
+        factories.Set(
+            key="FOO",
+            value="42",
+            timestamp=set_at,
+            by="me",
+            index=0,
+        )
+    ]
 
 
 def test_set_cannot_update_value():
@@ -31,10 +35,13 @@ def test_set_cannot_update_value():
             factories.Set(key="FOO", value="42"),
         ]
     )
-    toy_settings = operations.ToySettings(state=repo)
+    new_events: list[events.Event] = []
+    toy_settings = operations.ToySettings(state=repo, new_events=new_events)
 
     with pytest.raises(operations.AlreadySet):
         toy_settings.set("FOO", "43", timestamp=datetime.datetime.now(), by="me")
+
+    assert new_events == []
 
 
 def test_can_change_setting():
@@ -43,27 +50,33 @@ def test_can_change_setting():
             factories.Set(key="FOO", value="42", index=0),
         ]
     )
-    toy_settings = operations.ToySettings(state=repo)
+    new_events: list[events.Event] = []
+    toy_settings = operations.ToySettings(state=repo, new_events=new_events)
 
     changed_at = datetime.datetime.now()
-    new_events = toy_settings.change("FOO", "43", timestamp=changed_at, by="me")
+    toy_settings.change("FOO", "43", timestamp=changed_at, by="me")
 
-    assert new_events == factories.Changed(
-        key="FOO",
-        new_value="43",
-        timestamp=changed_at,
-        by="me",
-        index=1,
-    )
+    assert new_events == [
+        factories.Changed(
+            key="FOO",
+            new_value="43",
+            timestamp=changed_at,
+            by="me",
+            index=1,
+        )
+    ]
 
 
 def test_cannot_change_non_existent_setting():
     repo = MemoryRepo([])
-    toy_settings = operations.ToySettings(state=repo)
+    new_events: list[events.Event] = []
+    toy_settings = operations.ToySettings(state=repo, new_events=new_events)
 
     # check we are not allowed to change a setting that does not exist
     with pytest.raises(operations.NotSet):
         toy_settings.change("FOO", "42", timestamp=datetime.datetime.now(), by="me")
+
+    assert new_events == []
 
 
 def test_cannot_change_unset_setting():
@@ -73,11 +86,14 @@ def test_cannot_change_unset_setting():
             factories.Unset(key="FOO"),
         ]
     )
-    toy_settings = operations.ToySettings(state=repo)
+    new_events: list[events.Event] = []
+    toy_settings = operations.ToySettings(state=repo, new_events=new_events)
 
     # check we are not allowed to change a setting that has been unset
     with pytest.raises(operations.NotSet):
         toy_settings.change("FOO", "42", timestamp=datetime.datetime.now(), by="me")
+
+    assert new_events == []
 
 
 def test_unset_removes_value():
@@ -86,17 +102,20 @@ def test_unset_removes_value():
             factories.Set(key="FOO", value="42", index=0),
         ]
     )
-    toy_settings = operations.ToySettings(state=repo)
+    new_events: list[events.Event] = []
+    toy_settings = operations.ToySettings(state=repo, new_events=new_events)
 
     unset_at = datetime.datetime.now()
-    new_events = toy_settings.unset("FOO", timestamp=unset_at, by="me")
+    toy_settings.unset("FOO", timestamp=unset_at, by="me")
 
-    assert new_events == factories.Unset(
-        key="FOO",
-        timestamp=unset_at,
-        by="me",
-        index=1,
-    )
+    assert new_events == [
+        factories.Unset(
+            key="FOO",
+            timestamp=unset_at,
+            by="me",
+            index=1,
+        )
+    ]
 
 
 def test_unset_already_unset():
@@ -106,17 +125,23 @@ def test_unset_already_unset():
             factories.Unset(key="FOO"),
         ]
     )
-    toy_settings = operations.ToySettings(state=repo)
+    new_events: list[events.Event] = []
+    toy_settings = operations.ToySettings(state=repo, new_events=new_events)
 
     # check we are not allowed to unset it again
     with pytest.raises(operations.NotSet):
         toy_settings.unset("FOO", timestamp=datetime.datetime.now(), by="me")
+
+    assert new_events == []
 
 
 def test_unset_never_set():
     repo = MemoryRepo([])
-    toy_settings = operations.ToySettings(state=repo)
+    new_events: list[events.Event] = []
+    toy_settings = operations.ToySettings(state=repo, new_events=new_events)
 
     # check we are not allowed to unset it again
     with pytest.raises(operations.NotSet):
         toy_settings.unset("FOO", timestamp=datetime.datetime.now(), by="me")
+
+    assert new_events == []

--- a/toy_settings/application/services.py
+++ b/toy_settings/application/services.py
@@ -54,18 +54,11 @@ class ToySettings:
             AlreadySet: The setting already exists.
         """
         with unit_of_work.commit_on_success(self.committer) as new_events:
-            domain = operations.ToySettings(state=self.state)
+            domain = operations.ToySettings(state=self.state, new_events=new_events)
             try:
-                new_event = domain.set(
-                    key,
-                    value,
-                    timestamp=timestamp,
-                    by=by,
-                )
+                domain.set(key, value, timestamp=timestamp, by=by)
             except operations.AlreadySet as exc:
                 raise AlreadySet(key) from exc
-            else:
-                new_events.append(new_event)
 
     def change(
         self,
@@ -82,18 +75,11 @@ class ToySettings:
             NotSet: There is no setting for this key.
         """
         with unit_of_work.commit_on_success(self.committer) as new_events:
-            domain = operations.ToySettings(state=self.state)
+            domain = operations.ToySettings(state=self.state, new_events=new_events)
             try:
-                new_event = domain.change(
-                    key,
-                    new_value,
-                    timestamp=timestamp,
-                    by=by,
-                )
+                domain.change(key, new_value, timestamp=timestamp, by=by)
             except operations.NotSet as exc:
                 raise NotSet(key) from exc
-            else:
-                new_events.append(new_event)
 
     def unset(
         self,
@@ -109,14 +95,8 @@ class ToySettings:
             NotSet: There is no setting for this key.
         """
         with unit_of_work.commit_on_success(self.committer) as new_events:
-            domain = operations.ToySettings(state=self.state)
+            domain = operations.ToySettings(state=self.state, new_events=new_events)
             try:
-                new_event = domain.unset(
-                    key,
-                    timestamp=timestamp,
-                    by=by,
-                )
+                domain.unset(key, timestamp=timestamp, by=by)
             except operations.NotSet as exc:
                 raise NotSet(key) from exc
-            else:
-                new_events.append(new_event)

--- a/toy_settings/domain/operations.py
+++ b/toy_settings/domain/operations.py
@@ -21,6 +21,7 @@ class NotSet(Exception):
 @attrs.frozen
 class ToySettings:
     state: queries.Repository
+    new_events: list[events.Event]
 
     def set(
         self,
@@ -29,7 +30,7 @@ class ToySettings:
         *,
         timestamp: datetime.datetime,
         by: str,
-    ) -> events.Event:
+    ) -> None:
         """
         Create a new setting.
 
@@ -40,12 +41,14 @@ class ToySettings:
         if setting.value is not None:
             raise AlreadySet(key)
 
-        return events.Set(
-            index=setting.next_index,
-            timestamp=timestamp,
-            by=by,
-            key=key,
-            value=value,
+        self.new_events.append(
+            events.Set(
+                index=setting.next_index,
+                timestamp=timestamp,
+                by=by,
+                key=key,
+                value=value,
+            )
         )
 
     def change(
@@ -55,7 +58,7 @@ class ToySettings:
         *,
         timestamp: datetime.datetime,
         by: str,
-    ) -> events.Event:
+    ) -> None:
         """
         Change the current value of a setting.
 
@@ -66,12 +69,14 @@ class ToySettings:
         if setting.value is None:
             raise NotSet(key)
 
-        return events.Changed(
-            index=setting.next_index,
-            timestamp=timestamp,
-            by=by,
-            key=key,
-            new_value=new_value,
+        self.new_events.append(
+            events.Changed(
+                index=setting.next_index,
+                timestamp=timestamp,
+                by=by,
+                key=key,
+                new_value=new_value,
+            )
         )
 
     def unset(
@@ -80,7 +85,7 @@ class ToySettings:
         *,
         timestamp: datetime.datetime,
         by: str,
-    ) -> events.Event:
+    ) -> None:
         """
         Unset a setting.
 
@@ -91,9 +96,11 @@ class ToySettings:
         if setting.value is None:
             raise NotSet(key)
 
-        return events.Unset(
-            index=setting.next_index,
-            timestamp=timestamp,
-            by=by,
-            key=key,
+        self.new_events.append(
+            events.Unset(
+                index=setting.next_index,
+                timestamp=timestamp,
+                by=by,
+                key=key,
+            )
         )


### PR DESCRIPTION
Prior to this change, the domain service just returned an event rather
than "doing" something.

This change modifies that by passing the event list into the operations
and having them append events themselves. This means the operations
appear to be "doing" something, rather than just returning the event
that someone else needs to add to the committer.
